### PR TITLE
chore: add env config for adding annotations to ingress created by metacontroller webhook

### DIFF
--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -31,6 +31,7 @@ var (
 	serverShutdownDelayDuration   *time.Duration
 	gatewayContainerImageTag      string
 	gatewayNamespace              string
+	gatewayIngressAnnotations     map[string]string
 	gatewayHostFormat             string
 	gatewayPathFormat             string
 	gatewayHostScheme             string
@@ -70,8 +71,16 @@ func Initialize() {
 	frontendPosthogAPIHost = envutil.GetEnvOrNil("FRONTEND_POSTHOG_API_HOST")
 	frontendPosthogUIHost = envutil.GetEnvOrNil("FRONTEND_POSTHOG_UI_HOST")
 
-	gatewayContainerImageTag = envutil.GetEnvOrDefault("GATEWAY_CONTAINER_IMAGE_TAG", "ghcr.io/jetski-sh/mcp-proxy:0.1.0-alpha.4")
+	gatewayContainerImageTag = envutil.GetEnvOrDefault(
+		"GATEWAY_CONTAINER_IMAGE_TAG",
+		"ghcr.io/jetski-sh/mcp-proxy:0.1.0-alpha.4",
+	)
 	gatewayNamespace = envutil.GetEnvOrDefault("GATEWAY_NAMESPACE", "default")
+	gatewayIngressAnnotations = envutil.GetEnvParsedOrDefault(
+		"GATEWAY_INGRESS_ANNOTATIONS",
+		parseYAMLMap,
+		map[string]string{},
+	)
 	gatewayHostFormat = envutil.GetEnvOrDefault("GATEWAY_HOST_FORMAT", "%v.jetski.cloud")
 	gatewayPathFormat = envutil.GetEnvOrDefault("GATEWAY_PATH_FORMAT", "/%v/mcp")
 	gatewayHostScheme = envutil.GetEnvOrDefault("GATEWAY_HOST_SCHEME", "https")
@@ -167,6 +176,10 @@ func GatewayContainerImageTag() string {
 
 func GatewayNamespace() string {
 	return gatewayNamespace
+}
+
+func GatewayIngressAnnotations() map[string]string {
+	return gatewayIngressAnnotations
 }
 
 func GatewayHostFormat() string {

--- a/internal/env/parse.go
+++ b/internal/env/parse.go
@@ -1,0 +1,8 @@
+package env
+
+import "gopkg.in/yaml.v3"
+
+func parseYAMLMap(input string) (result map[string]string, err error) {
+	err = yaml.Unmarshal([]byte(input), &result)
+	return
+}

--- a/internal/kubernetes/webhook/types.go
+++ b/internal/kubernetes/webhook/types.go
@@ -96,8 +96,12 @@ func (req *request) GetDesiredChildren() ([]client.Object, error) {
 			},
 		},
 		&networkingv1.Ingress{
-			TypeMeta:   metav1.TypeMeta{APIVersion: "networking.k8s.io/v1", Kind: "Ingress"},
-			ObjectMeta: metav1.ObjectMeta{Name: req.Parent.Name, Namespace: req.Parent.Namespace},
+			TypeMeta: metav1.TypeMeta{APIVersion: "networking.k8s.io/v1", Kind: "Ingress"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        req.Parent.Name,
+				Namespace:   req.Parent.Namespace,
+				Annotations: env.GatewayIngressAnnotations(),
+			},
 			Spec: networkingv1.IngressSpec{
 				Rules: []networkingv1.IngressRule{{
 					Host: fmt.Sprintf(env.GatewayHostFormat(), req.Parent.Spec.OrganizationName),


### PR DESCRIPTION
can test with
```toml
[env]
_.file = '.env.development.local'
GATEWAY_INGRESS_ANNOTATIONS = '''
hello: world
foo: bar
'''
```