### PR TITLE
chore: lower gateway resource requests

### DIFF
--- a/internal/handlers/webhook/kubernetes/types.go
+++ b/internal/handlers/webhook/kubernetes/types.go
@@ -75,8 +75,8 @@ func (req *request) GetDesiredChildren() ([]client.Object, error) {
 									corev1.ResourceCPU:    resource.MustParse("500m"),
 								},
 								Requests: corev1.ResourceList{
-									corev1.ResourceMemory: resource.MustParse("128Mi"),
-									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("16Mi"),
+									corev1.ResourceCPU:    resource.MustParse("5m"),
 								},
 							},
 							Ports:        []corev1.ContainerPort{{Name: "http", ContainerPort: 9000}},


### PR DESCRIPTION
current usage is very low:

```
└─> kubectl top pods -n jetski-production-projects
NAME                                       CPU(cores)   MEMORY(bytes)
demo-gateway-78bc9d9568-5nxjx              1m           7Mi
freestyle-gateway-77b84bf569-swl4r         0m           12Mi
kosmoz-gateway-c88f74b74-tqrn6             1m           4Mi
mcp-instructions-server-7fbbd784b8-l7ln6   1m           72Mi
mcp-server-556bbf766c-gpbdl                2m           59Mi
pm-gateway-5b964dcf94-4r8n8                1m           4Mi
video-org-gateway-58799c87f8-l74zv         1m           5Mi
who-am-i-server-5f8f6469d5-99k6g           0m           81Mi
```